### PR TITLE
Fix Type error

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,7 +11,7 @@ export interface DevOptions {
   silent?: boolean;
   force?: boolean;
   proxy?: ProxyItem[];
-  dirs?: [string];
+  dirs?: string[];
   dirname?: string;
   spa?: (boolean | string);
   port?: number;


### PR DESCRIPTION
Type for "dirs" in "DevOptions" is incorrect, and will cause a lint error.